### PR TITLE
Fixed calibration file path to proxy via src folder

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
       - teleop
       - smoother
     volumes:
-      - ./calibration_settings.yaml:/root/minipupper_ws/servo_interface/config/calibration_settings.yaml
+      - ./calibration_settings.yaml:/root/minipupper_ws/src/servo_interface/config/calibration_settings.yaml
       - /sys/class/pwm/pwmchip0:/sys/class/pwm/pwmchip0
       - /sys/class/gpio:/sys/class/gpio
     environment:


### PR DESCRIPTION
Fixed an issue in the volume path causing the docker images to ignore the custom calibration file.